### PR TITLE
Update requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -25,3 +25,4 @@ pi-ina219==1.4.*
 RPi.bme280==0.2.*
 Pillow==8.2.*
 jenkspy==0.2.*
+fake-rpi==0.7.*


### PR DESCRIPTION
Add fake-rpi==0.7.* to requirements.txt
so Tests work with standard pi python setup as defined by requirements.txt